### PR TITLE
Change special character handling

### DIFF
--- a/lib/cracker.rb
+++ b/lib/cracker.rb
@@ -10,6 +10,7 @@ class Cracker < Cryptor
   end
 
   def crack_key(cipher, date)
+    cipher = remove_characters(cipher.downcase.split(//))[:remaining_chars]
     offsets = (date.to_i ** 2).digits.reverse[-4..-1]
     shift_amounts = get_shift_amounts(cipher)
     ordered_shift_amounts = order_shift_amounts(shift_amounts, (cipher.length - 1) % 4)
@@ -20,11 +21,10 @@ class Cracker < Cryptor
   end
 
   def get_shift_amounts(cipher)
-    character_set = ("a".."z").to_a << " "
     expected_chars = [" ", "e", "n", "d"]
-    cipher_last_four = cipher.split(//)[-4..-1]
+    cipher_last_four = cipher[-4..-1]
     expected_chars.map.with_index do |expected_char, i|
-      character_set.index(cipher_last_four[i]) - character_set.index(expected_char)
+      CHARACTER_SET.index(cipher_last_four[i]) - CHARACTER_SET.index(expected_char)
     end
   end
 

--- a/lib/cryptor.rb
+++ b/lib/cryptor.rb
@@ -17,9 +17,9 @@ class Cryptor
     removed_chars = split_chars[:removed_chars]
     encrypted = characters.map.with_index do |character, i|
       @shifters[i % 4].shift_character(character)
-    end.join
-    # final_encryption = insert_removed_chars(encrypted, removed_chars)
-    # final_encryption.join
+    end
+    final_encryption = insert_removed_chars(encrypted, removed_chars)
+    final_encryption.join
   end
 
   def remove_characters(characters)
@@ -31,6 +31,10 @@ class Cryptor
     {removed_chars: removed_chars, remaining_chars: remaining_chars}
   end
 
-
+  def insert_removed_chars(encrypted, removed_chars)
+    removed_chars.inject(encrypted) do |encrypted, (i, char)|
+      encrypted.insert(i, char)
+    end
+  end
 
 end

--- a/lib/cryptor.rb
+++ b/lib/cryptor.rb
@@ -2,6 +2,8 @@ require './lib/shifter'
 
 class Cryptor
 
+  CHARACTER_SET = ("a".."z").to_a << " "
+
   attr_reader :shifters
 
   def initialize(key, date, action)
@@ -9,10 +11,26 @@ class Cryptor
   end
 
   def run(input)
-    characters = input.split(//)
-    characters.map.with_index do |character, i|
+    characters = input.downcase.split(//)
+    split_chars = remove_characters(characters)
+    characters = split_chars[:remaining_chars]
+    removed_chars = split_chars[:removed_chars]
+    encrypted = characters.map.with_index do |character, i|
       @shifters[i % 4].shift_character(character)
     end.join
+    # final_encryption = insert_removed_chars(encrypted, removed_chars)
+    # final_encryption.join
   end
+
+  def remove_characters(characters)
+    removed_chars = {}
+    remaining_chars = []
+    characters.each_with_index do |char, i|
+      CHARACTER_SET.include?(char) ? remaining_chars << char : removed_chars[i] = char
+    end
+    {removed_chars: removed_chars, remaining_chars: remaining_chars}
+  end
+
+
 
 end

--- a/lib/shifter.rb
+++ b/lib/shifter.rb
@@ -1,20 +1,17 @@
 class Shifter
 
+  CHARACTER_SET = ("a".."z").to_a << " "
+
   attr_reader :shift
 
   def initialize(shift)
     @shift = shift
-    @character_set = ("a".."z").to_a << " "
   end
 
   def shift_character(character)
     character.downcase!
-    if @character_set.include?(character)
-      new_character_index = (@character_set.index(character) + @shift) % 27
-      @character_set[new_character_index]
-    else
-      character
-    end
+    new_character_index = (CHARACTER_SET.index(character) + @shift) % 27
+    CHARACTER_SET[new_character_index]
   end
 
   def self.generate_shifters(key, date, action)

--- a/lib/shifter.rb
+++ b/lib/shifter.rb
@@ -9,7 +9,6 @@ class Shifter
   end
 
   def shift_character(character)
-    character.downcase!
     new_character_index = (CHARACTER_SET.index(character) + @shift) % 27
     CHARACTER_SET[new_character_index]
   end

--- a/spec/cryptor_spec.rb
+++ b/spec/cryptor_spec.rb
@@ -13,7 +13,16 @@ RSpec.describe Cryptor do
     end
 
     it 'can encrypt edge cases' do
-      expect(encryptor.run("Hello! WORLD?")).to eq("keder!sprrdx?")
+      expect(encryptor.run("Hello! WORLD?")).to eq("keder! ohulw?")
+    end
+
+    it 'can remove characters no in the characters set and store them for post encryption insertion' do
+      input_chars = ["a", "b", "3", "c", "d", "?", "e", "!", "f"]
+      expected = {
+        removed_chars: { 2 => "3", 5 => "?" , 7 => "!" },
+        remaining_chars: ["a", "b", "c", "d", "e", "f"]
+      }
+      expect(encryptor.remove_characters(input_chars)).to eq(expected)
     end
   end
 
@@ -30,7 +39,7 @@ RSpec.describe Cryptor do
     end
   
     it 'can decrypt edge cases' do
-      expect(decryptor.run("keder!sprrdx?")).to eq("hello! world?")
+      expect(decryptor.run("keder! ohulw?")).to eq("hello! world?")
     end
 
   end

--- a/spec/shifter_spec.rb
+++ b/spec/shifter_spec.rb
@@ -16,10 +16,6 @@ RSpec.describe Shifter do
       expect(d_shifter.shift_character("l")).to eq("e")
     end
 
-    it 'encrypts capitals as lowercase' do
-      expect(d_shifter.shift_character("L")).to eq("e")
-    end
-
     it 'can factory itself for encryption' do
       shifters = Shifter.generate_shifters("02715", "040895", :encrypt)
       expect(shifters).to all(be_instance_of(Shifter))

--- a/spec/shifter_spec.rb
+++ b/spec/shifter_spec.rb
@@ -16,11 +16,6 @@ RSpec.describe Shifter do
       expect(d_shifter.shift_character("l")).to eq("e")
     end
 
-    it 'doesnt shift characters not in the character set' do
-      expect(d_shifter.shift_character("!")).to eq("!")
-      expect(d_shifter.shift_character("6")).to eq("6")
-    end
-
     it 'encrypts capitals as lowercase' do
       expect(d_shifter.shift_character("L")).to eq("e")
     end


### PR DESCRIPTION
Overhauled everything so that character not in the character set are encrypted differently.

non-included characters are removed from the input before running through the encryption

they are then reinserted after encryption is complete.

this means that the same message with other characters added in is still encrypted the same way.